### PR TITLE
Adding cross-compiler functionality

### DIFF
--- a/canopencgi/Makefile
+++ b/canopencgi/Makefile
@@ -14,7 +14,7 @@ SOURCES =       $(APPL_SRC)/CANopenCGI.c
 
 
 OBJS = $(SOURCES:%.c=%.o)
-CC = gcc
+CC ?= gcc
 CFLAGS = -Wall -g $(INCLUDE_DIRS)
 LDFLAGS = 
 

--- a/canopencomm/Makefile
+++ b/canopencomm/Makefile
@@ -14,7 +14,7 @@ SOURCES =       $(APPL_SRC)/CANopenCommand.c
 
 
 OBJS = $(SOURCES:%.c=%.o)
-CC = gcc
+CC ?= gcc
 CFLAGS = -Wall -g $(INCLUDE_DIRS)
 LDFLAGS = 
 

--- a/canopend/Makefile
+++ b/canopend/Makefile
@@ -53,7 +53,7 @@ SOURCES =       $(STACKDRV_SRC)/CO_driver.c         \
 
 
 OBJS = $(SOURCES:%.c=%.o)
-CC = gcc
+CC ?= gcc
 CFLAGS = -Wall -g $(INCLUDE_DIRS)
 LDFLAGS = -lrt -pthread
 


### PR DESCRIPTION
Changing the Makefiles for canopencomm, canopencgi, and canopend to be
cross-compiled.
